### PR TITLE
kgo: reduce allocations when processing batches

### DIFF
--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -454,6 +454,7 @@ func NewClient(opts ...Opt) (*Client, error) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+
 	cl := &Client{
 		cfg:       cfg,
 		opts:      opts,

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/twmb/franz-go/pkg/kerr"
-	"github.com/twmb/franz-go/pkg/kgo/internal/pool"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"github.com/twmb/franz-go/pkg/sasl"
 )
@@ -452,15 +451,6 @@ func NewClient(opts ...Opt) (*Client, error) {
 				}).DialContext(ctx, network, host)
 			}
 		}
-	}
-
-	// Allow reusing decompression buffers if record pooling has been enabled
-	// via EnableRecordsPool option.
-	var decompressorPool *pool.BucketedPool[byte]
-	if cfg.recordsPool.p != nil {
-		decompressorPool = pool.NewBucketedPool[byte](1024, maxPoolDecodedBufferSize, 2, func(size int) []byte {
-			return make([]byte, 0, size)
-		})
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -458,7 +458,7 @@ func NewClient(opts ...Opt) (*Client, error) {
 	// via EnableRecordsPool option.
 	var decompressorPool *pool.BucketedPool[byte]
 	if cfg.recordsPool.p != nil {
-		decompressorPool = pool.NewBucketedPool[byte](1024, maxDecompressBufferSize, 2, func(size int) []byte {
+		decompressorPool = pool.NewBucketedPool[byte](1024, maxPoolDecodedBufferSize, 2, func(size int) []byte {
 			return make([]byte, 0, size)
 		})
 	}

--- a/pkg/kgo/compression.go
+++ b/pkg/kgo/compression.go
@@ -276,17 +276,11 @@ func (d *decompressor) decompress(src []byte, codec byte, pool *pool.BucketedPoo
 	}
 	var out *bytes.Buffer
 
-	if pool != nil {
-		outBuf := pool.Get(pool.MaxSize())[:0]
-		defer func() {
-			pool.Put(outBuf)
-		}()
-		out = bytes.NewBuffer(outBuf)
-	} else {
-		out = byteBuffers.Get().(*bytes.Buffer)
-		out.Reset()
-		defer byteBuffers.Put(out)
-	}
+	outBuf := pool.Get(pool.MaxSize())[:0]
+	defer func() {
+		pool.Put(outBuf)
+	}()
+	out = bytes.NewBuffer(outBuf)
 
 	switch compCodec {
 	case codecGzip:

--- a/pkg/kgo/compression.go
+++ b/pkg/kgo/compression.go
@@ -14,9 +14,9 @@ import (
 	"github.com/pierrec/lz4/v4"
 )
 
-const maxDecompressBufferSize = 32 * 1024 * 1024 // 32MB
+const maxPoolDecodedBufferSize = 32 * 1024 * 1024 // 32MB
 
-var byteBuffers = sync.Pool{New: func() any { return bytes.NewBuffer(make([]byte, maxDecompressBufferSize)) }}
+var byteBuffers = sync.Pool{New: func() any { return bytes.NewBuffer(make([]byte, maxPoolDecodedBufferSize)) }}
 
 type codecType int8
 
@@ -277,7 +277,7 @@ func (d *decompressor) decompress(src []byte, codec byte) ([]byte, error) {
 	out := byteBuffers.Get().(*bytes.Buffer)
 	out.Reset()
 	defer func() {
-		if out.Cap() > maxDecompressBufferSize {
+		if out.Cap() > maxPoolDecodedBufferSize {
 			return // avoid keeping large buffers in the pool
 		}
 		byteBuffers.Put(out)

--- a/pkg/kgo/compression.go
+++ b/pkg/kgo/compression.go
@@ -351,8 +351,8 @@ func (d *decompressor) getDecodedBuffer(src []byte, compCodec codecType, pool *p
 
 func (d *decompressor) copyDecodedBuffer(decoded []byte, compCodec codecType, pool *pool.BucketedPool[byte]) []byte {
 	if compCodec == codecSnappy || compCodec == codecLZ4 {
-		// We already know the size of the decoded buffer, so there's no need to
-		// copy it.
+		// We already know the actual size of the decoded buffer before decompression,
+		// so there's no need to copy the buffer.
 		return decoded
 	}
 	out := pool.Get(len(decoded))

--- a/pkg/kgo/compression.go
+++ b/pkg/kgo/compression.go
@@ -280,7 +280,7 @@ func (d *decompressor) decompress(src []byte, codec byte, pool *pool.BucketedPoo
 		return nil, err
 	}
 	defer func() {
-		if compCodec == codecSnappy || compCodec == codecLZ4 {
+		if compCodec == codecSnappy {
 			return
 		}
 		pool.Put(buf)
@@ -339,12 +339,6 @@ func (d *decompressor) getDecodedBuffer(src []byte, compCodec codecType, pool *p
 			return nil, nil, err
 		}
 
-	case codecLZ4:
-		unlz4 := d.unlz4Pool.Get().(*lz4.Reader)
-		defer d.unlz4Pool.Put(unlz4)
-		unlz4.Reset(bytes.NewReader(src))
-		decodedBufSize = unlz4.Size()
-
 	default:
 		// Make a guess at the output size.
 		decodedBufSize = len(src) * 2
@@ -355,7 +349,7 @@ func (d *decompressor) getDecodedBuffer(src []byte, compCodec codecType, pool *p
 }
 
 func (d *decompressor) copyDecodedBuffer(decoded []byte, compCodec codecType, pool *pool.BucketedPool[byte]) []byte {
-	if compCodec == codecSnappy || compCodec == codecLZ4 {
+	if compCodec == codecSnappy {
 		// We already know the actual size of the decoded buffer before decompression,
 		// so there's no need to copy the buffer.
 		return decoded

--- a/pkg/kgo/compression.go
+++ b/pkg/kgo/compression.go
@@ -275,7 +275,7 @@ func (d *decompressor) decompress(src []byte, codec byte, pool *pool.BucketedPoo
 		return src, nil
 	}
 
-	out, buf, err := d.getOutputBuffer(src, compCodec, pool)
+	out, buf, err := d.getDecodedBuffer(src, compCodec, pool)
 	if err != nil {
 		return nil, err
 	}
@@ -322,7 +322,7 @@ func (d *decompressor) decompress(src []byte, codec byte, pool *pool.BucketedPoo
 	}
 }
 
-func (d *decompressor) getOutputBuffer(src []byte, compCodec codecType, pool *pool.BucketedPool[byte]) (*bytes.Buffer, []byte, error) {
+func (d *decompressor) getDecodedBuffer(src []byte, compCodec codecType, pool *pool.BucketedPool[byte]) (*bytes.Buffer, []byte, error) {
 	var (
 		decodedBufSize int
 		err error

--- a/pkg/kgo/compression.go
+++ b/pkg/kgo/compression.go
@@ -279,7 +279,12 @@ func (d *decompressor) decompress(src []byte, codec byte, pool *pool.BucketedPoo
 	if err != nil {
 		return nil, err
 	}
-	defer pool.Put(buf)
+	defer func() {
+		if compCodec == codecSnappy || compCodec == codecLZ4 {
+			return
+		}
+		pool.Put(buf)
+	}()
 
 	switch compCodec {
 	case codecGzip:

--- a/pkg/kgo/compression_test.go
+++ b/pkg/kgo/compression_test.go
@@ -71,7 +71,7 @@ func TestCompressDecompress(t *testing.T) {
 	}
 
 	t.Parallel()
-	d := newDecompressor()
+	d := newDecompressor(nil)
 	inputs := [][]byte{
 		randStr(1 << 2),
 		randStr(1 << 5),
@@ -155,7 +155,7 @@ func BenchmarkDecompress(b *testing.B) {
 
 		b.Run(fmt.Sprint(codec), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				d := newDecompressor()
+				d := newDecompressor(nil)
 				d.decompress(w.Bytes(), byte(codec))
 			}
 		})

--- a/pkg/kgo/compression_test.go
+++ b/pkg/kgo/compression_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/pierrec/lz4/v4"
+
+	"github.com/twmb/franz-go/pkg/kgo/internal/pool"
 )
 
 // Regression test for #778.
@@ -156,7 +158,7 @@ func BenchmarkDecompress(b *testing.B) {
 		b.Run(fmt.Sprint(codec), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				d := newDecompressor()
-				d.decompress(w.Bytes(), byte(codec), nil)
+				d.decompress(w.Bytes(), byte(codec), pool.NewBucketedPool(1, 1<<16, 2, func(int) []byte { return make([]byte, 1<<16) }))
 			}
 		})
 		byteBuffers.Put(w)

--- a/pkg/kgo/compression_test.go
+++ b/pkg/kgo/compression_test.go
@@ -80,6 +80,8 @@ func TestCompressDecompress(t *testing.T) {
 		randStr(1 << 8),
 	}
 
+	buffPool := pool.NewBucketedPool(1, 1<<16, 2, func(int) []byte { return make([]byte, 1<<16) })
+
 	var wg sync.WaitGroup
 	for _, produceVersion := range []int16{
 		0, 7,
@@ -112,7 +114,7 @@ func TestCompressDecompress(t *testing.T) {
 							w.Reset()
 
 							got, used := c.compress(w, in, produceVersion)
-							got, err := d.decompress(got, byte(used), nil)
+							got, err := d.decompress(got, byte(used), buffPool)
 							if err != nil {
 								t.Errorf("unexpected decompress err: %v", err)
 								return

--- a/pkg/kgo/compression_test.go
+++ b/pkg/kgo/compression_test.go
@@ -71,7 +71,7 @@ func TestCompressDecompress(t *testing.T) {
 	}
 
 	t.Parallel()
-	d := newDecompressor(nil)
+	d := newDecompressor()
 	inputs := [][]byte{
 		randStr(1 << 2),
 		randStr(1 << 5),
@@ -110,7 +110,7 @@ func TestCompressDecompress(t *testing.T) {
 							w.Reset()
 
 							got, used := c.compress(w, in, produceVersion)
-							got, err := d.decompress(got, byte(used))
+							got, err := d.decompress(got, byte(used), nil)
 							if err != nil {
 								t.Errorf("unexpected decompress err: %v", err)
 								return
@@ -155,8 +155,8 @@ func BenchmarkDecompress(b *testing.B) {
 
 		b.Run(fmt.Sprint(codec), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				d := newDecompressor(nil)
-				d.decompress(w.Bytes(), byte(codec))
+				d := newDecompressor()
+				d.decompress(w.Bytes(), byte(codec), nil)
 			}
 		})
 		byteBuffers.Put(w)

--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -16,6 +16,8 @@ import (
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"github.com/twmb/franz-go/pkg/kversion"
 	"github.com/twmb/franz-go/pkg/sasl"
+
+	"github.com/twmb/franz-go/pkg/kgo/internal/pool"
 )
 
 // Opt is an option to configure a client.
@@ -151,7 +153,8 @@ type cfg struct {
 	partitions map[string]map[int32]Offset // partitions to directly consume from
 	regex      bool
 
-	recordsPool recordsPool
+	recordsPool          *recordsPool
+	decompressBufferPool *pool.BucketedPool[byte]
 
 	////////////////////////////
 	// CONSUMER GROUP SECTION //
@@ -391,6 +394,14 @@ func (cfg *cfg) validate() error {
 	}
 	cfg.hooks = processedHooks
 
+	if cfg.recordsPool != nil {
+		// Assume a 2x compression ratio.
+		maxDecompressedBatchSize := int(cfg.maxBytes.load()) * 2
+
+		cfg.decompressBufferPool = pool.NewBucketedPool[byte](4096, maxDecompressedBatchSize, 2, func(sz int) []byte {
+			return make([]byte, sz)
+		})
+	}
 	return nil
 }
 

--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -394,14 +394,11 @@ func (cfg *cfg) validate() error {
 	}
 	cfg.hooks = processedHooks
 
-	if cfg.recordsPool != nil {
-		// Assume a 2x compression ratio.
-		maxDecompressedBatchSize := int(cfg.maxBytes.load()) * 2
-
-		cfg.decompressBufferPool = pool.NewBucketedPool[byte](4096, maxDecompressedBatchSize, 2, func(sz int) []byte {
-			return make([]byte, sz)
-		})
-	}
+	// Assume a 2x compression ratio.
+	maxDecompressedBatchSize := int(cfg.maxBytes.load()) * 2
+	cfg.decompressBufferPool = pool.NewBucketedPool[byte](4096, maxDecompressedBatchSize, 2, func(sz int) []byte {
+		return make([]byte, sz)
+	})
 	return nil
 }
 

--- a/pkg/kgo/internal/pool/bucketed_pool.go
+++ b/pkg/kgo/internal/pool/bucketed_pool.go
@@ -1,0 +1,92 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pool
+
+import (
+	"sync"
+)
+
+// BucketedPool is a bucketed pool for variably sized slices.
+type BucketedPool[T any] struct {
+	buckets []sync.Pool
+	sizes   []int
+	// make is the function used to create an empty slice when none exist yet.
+	make func(int) []T
+}
+
+// NewBucketedPool returns a new BucketedPool with size buckets for minSize to maxSize
+// increasing by the given factor.
+func NewBucketedPool[T any](minSize, maxSize int, factor float64, makeFunc func(int) []T) *BucketedPool[T] {
+	if minSize < 1 {
+		panic("invalid minimum pool size")
+	}
+	if maxSize < 1 {
+		panic("invalid maximum pool size")
+	}
+	if factor < 1 {
+		panic("invalid factor")
+	}
+
+	var sizes []int
+
+	for s := minSize; s <= maxSize; s = int(float64(s) * factor) {
+		sizes = append(sizes, s)
+	}
+
+	p := &BucketedPool[T]{
+		buckets: make([]sync.Pool, len(sizes)),
+		sizes:   sizes,
+		make:    makeFunc,
+	}
+	return p
+}
+
+// Get returns a new slice with capacity greater than or equal to size.
+func (p *BucketedPool[T]) Get(size int) []T {
+	for i, bktSize := range p.sizes {
+		if size > bktSize {
+			continue
+		}
+		buff := p.buckets[i].Get()
+		if buff == nil {
+			buff = p.make(bktSize)
+		}
+		return buff.([]T)
+	}
+	return p.make(size)
+}
+
+// Put adds a slice to the right bucket in the pool.
+// If the slice does not belong to any bucket in the pool, it is ignored.
+func (p *BucketedPool[T]) Put(s []T) {
+	sCap := cap(s)
+	if sCap < p.sizes[0] {
+		return
+	}
+
+	for i, size := range p.sizes {
+		if sCap > size {
+			continue
+		}
+
+		if sCap == size {
+			// Buffer is exactly the minimum size for this bucket. Add it to this bucket.
+			p.buckets[i].Put(s)
+		} else {
+			// Buffer belongs in previous bucket.
+			p.buckets[i-1].Put(s)
+		}
+		return
+	}
+}

--- a/pkg/kgo/internal/pool/bucketed_pool.go
+++ b/pkg/kgo/internal/pool/bucketed_pool.go
@@ -90,3 +90,8 @@ func (p *BucketedPool[T]) Put(s []T) {
 		return
 	}
 }
+
+// MaxSize returns the maximum size of a slice in the pool.
+func (p *BucketedPool[T]) MaxSize() int {
+	return p.sizes[len(p.sizes)-1]
+}

--- a/pkg/kgo/internal/pool/bucketed_pool.go
+++ b/pkg/kgo/internal/pool/bucketed_pool.go
@@ -91,7 +91,4 @@ func (p *BucketedPool[T]) Put(s []T) {
 	}
 }
 
-// MaxSize returns the maximum size of a slice in the pool.
-func (p *BucketedPool[T]) MaxSize() int {
-	return p.sizes[len(p.sizes)-1]
-}
+

--- a/pkg/kgo/internal/pool/bucketed_pool_test.go
+++ b/pkg/kgo/internal/pool/bucketed_pool_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Provenance-includes-location: https://github.com/prometheus/prometheus/blob/main/util/pool/pool_test.go
+// Provenance-includes-copyright: The Prometheus Authors
+
+package pool
+
+import (
+	"testing"
+)
+
+func makeFunc(size int) []int {
+	return make([]int, 0, size)
+}
+
+func TestBucketedPool_HappyPath(t *testing.T) {
+	testPool := NewBucketedPool(1, 8, 2, makeFunc)
+	cases := []struct {
+		size        int
+		expectedCap int
+	}{
+		{
+			size:        -1,
+			expectedCap: 1,
+		},
+		{
+			size:        3,
+			expectedCap: 4,
+		},
+		{
+			size:        10,
+			expectedCap: 10,
+		},
+	}
+	for _, c := range cases {
+		ret := testPool.Get(c.size)
+		if cap(ret) < c.expectedCap {
+			t.Fatalf("expected cap >= %d, got %d", c.expectedCap , cap(ret))
+		}
+		testPool.Put(ret)
+	}
+}
+
+func TestBucketedPool_SliceNotAlignedToBuckets(t *testing.T) {
+	pool := NewBucketedPool(1, 1000, 10, makeFunc)
+	pool.Put(make([]int, 0, 2))
+	s := pool.Get(3)
+	if cap(s) < 3 {
+		t.Fatalf("expected cap >= 3, got %d", cap(s))
+	}
+}
+
+func TestBucketedPool_PutEmptySlice(t *testing.T) {
+	pool := NewBucketedPool(1, 1000, 10, makeFunc)
+	pool.Put([]int{})
+	s := pool.Get(1)
+	if cap(s) < 1 {
+		t.Fatalf("expected cap >= 1, got %d", cap(s))
+	}
+}
+
+func TestBucketedPool_PutSliceSmallerThanMinimum(t *testing.T) {
+	pool := NewBucketedPool(3, 1000, 10, makeFunc)
+	pool.Put([]int{1, 2})
+	s := pool.Get(3)
+	if cap(s) < 3 {
+		t.Fatalf("expected cap >= 3, got %d", cap(s))
+	}
+}

--- a/pkg/kgo/record_and_fetch.go
+++ b/pkg/kgo/record_and_fetch.go
@@ -154,13 +154,24 @@ type Record struct {
 	//
 	// When reused, record is returned to this pool.
 	recordsPool recordsPool
+
+	// rcBatchBuffer is used to keep track of the raw buffer that this record was
+	// derived from when consuming, after decompression.
+	//
+	// This is used to allow reusing these buffers when record pooling has been enabled
+	// via EnableRecordsPool option.
+	rcBatchBuffer *rcBuffer[byte]
 }
 
 // Reuse releases the record back to the pool.
 //
+//
 // Once this method has been called, any reference to the passed record should be considered invalid by the caller,
 // as it may be reused as a result of future calls to the PollFetches/PollRecords method.
 func (r *Record) Reuse() {
+	if r.rcBatchBuffer != nil {
+		r.rcBatchBuffer.release()
+	}
 	r.recordsPool.put(r)
 }
 

--- a/pkg/kgo/record_and_fetch.go
+++ b/pkg/kgo/record_and_fetch.go
@@ -155,7 +155,7 @@ type Record struct {
 	// recordsPool is the pool that this record was fetched from, if any.
 	//
 	// When reused, record is returned to this pool.
-	recordsPool recordsPool
+	recordsPool *recordsPool
 
 	// rcBatchBuffer is used to keep track of the raw buffer that this record was
 	// derived from when consuming, after decompression.
@@ -178,13 +178,11 @@ type Record struct {
 // Once this method has been called, any reference to the passed record should be considered invalid by the caller,
 // as it may be reused as a result of future calls to the PollFetches/PollRecords method.
 func (r *Record) Reuse() {
-	if r.rcRawRecordsBuffer != nil {
+	if r.recordsPool != nil {
 		r.rcRawRecordsBuffer.release()
-	}
-	if r.rcBatchBuffer != nil {
 		r.rcBatchBuffer.release()
+		r.recordsPool.put(r)
 	}
-	r.recordsPool.put(r)
 }
 
 func (r *Record) userSize() int64 {

--- a/pkg/kgo/source.go
+++ b/pkg/kgo/source.go
@@ -55,8 +55,8 @@ func newRCBuffer[T any](buffer []T, pool *pool.BucketedPool[T]) *rcBuffer[T] {
 	return &rcBuffer[T]{buffer: buffer, pool: pool}
 }
 
-func (b *rcBuffer[T]) add(delta int32) {
-	b.refCount.Add(delta)
+func (b *rcBuffer[T]) acquire() {
+	b.refCount.Add(1)
 }
 
 func (b *rcBuffer[T]) release() {
@@ -1854,11 +1854,11 @@ func (o *cursorOffsetNext) maybeKeepRecord(fp *FetchPartition, record *Record, r
 	}
 	if !abort {
 		if rcBatchBuff != nil {
-			rcBatchBuff.add(1)
+			rcBatchBuff.acquire()
 			record.rcBatchBuffer = rcBatchBuff
 		}
 		if rcRawRecordsBuff != nil {
-			rcRawRecordsBuff.add(1)
+			rcRawRecordsBuff.acquire()
 			record.rcRawRecordsBuffer = rcRawRecordsBuff
 		}
 		fp.Records = append(fp.Records, record)

--- a/pkg/kgo/source.go
+++ b/pkg/kgo/source.go
@@ -1851,8 +1851,9 @@ func (o *ProcessFetchPartitionOptions) maybeKeepRecord(fp *FetchPartition, recor
 	if !abort {
 		if rcBatchBuff != nil && rcRawRecordsBuff != nil {
 			rcBatchBuff.acquire()
-			rcRawRecordsBuff.acquire()
 			record.rcBatchBuffer = rcBatchBuff
+
+			rcRawRecordsBuff.acquire()
 			record.rcRawRecordsBuffer = rcRawRecordsBuff
 		}
 		fp.Records = append(fp.Records, record)

--- a/pkg/kgo/source.go
+++ b/pkg/kgo/source.go
@@ -1616,7 +1616,7 @@ func processRecordBatch(
 		rcBatchBuff      *rcBuffer[byte]
 		rcRawRecordsBuff *rcBuffer[kmsg.Record]
 	)
-	if o.DecompressBufferPool != nil {
+	if o.recordPool != nil {
 		rcBatchBuff = newRCBuffer(rawRecords, o.DecompressBufferPool)
 		rcRawRecordsBuff = newRCBuffer(krecords, rawRecordsPool)
 	}

--- a/pkg/kgo/source.go
+++ b/pkg/kgo/source.go
@@ -1539,7 +1539,7 @@ func (a aborter) trackAbortedPID(producerID int64) {
 // processing records to fetch part //
 //////////////////////////////////////
 
-var rawRecordsPool = pool.NewBucketedPool[kmsg.Record](32, 4096, 2, func(len int) []kmsg.Record {
+var rawRecordsPool = pool.NewBucketedPool[kmsg.Record](32, 16*1024, 2, func(len int) []kmsg.Record {
 	return make([]kmsg.Record, len)
 })
 


### PR DESCRIPTION
This PR introduces various changes in order to reduce GC overhead by decreasing the total number of allocations when the `EnableRecordsPool` option is set.

Among the changes introduced, the following are noteworthy:

1. A dedicated pool is used during message batch decompression, in order to reduce number of allocations and to avoid a potential [pool poisoning](https://github.com/golang/go/issues/23199#issuecomment-353193866) scenario.

2. The possibility of reusing the final output buffers derived from the decompression of a batch has been introduced, after invoking `*kgo.(*Record).Reuse` on all the resulting records.

3. Similarly, once `*kgo.(*Record).Reuse` has been invoked on all the resulting records of a batch, the possibility of recycling the intermediate `[]kmsg.Record` buffers generated during the batch processing has been introduced.